### PR TITLE
Using fullnode and solidity node remapping

### DIFF
--- a/tronbox.js
+++ b/tronbox.js
@@ -5,8 +5,8 @@ module.exports = {
       privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
       consume_user_resource_percent: 30,
       fee_limit: 100000000,
-      fullNode: "https://api.trongrid.io:8090",
-      solidityNode: "https://api.trongrid.io:8091",
+      fullNode: "https://api.trongrid.io",
+      solidityNode: "https://api.trongrid.io",
       eventServer: "https://api.trongrid.io",
       network_id: "*" // Match any network id
     }


### PR DESCRIPTION
This uses the remapped fullnode and solidity nodes on api.trongrid.io, avoiding issues with corporate networks which don't allow to access https on ports other than 443.