### PR TITLE
Using a mononode with TB 2.1.9 and TQ 1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "anymatch": {
       "version": "1.3.2",
@@ -365,16 +368,14 @@
       "dev": true
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chokidar": {
@@ -449,6 +450,21 @@
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "commander": {
       "version": "2.18.0",
@@ -1489,6 +1505,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-value": {
@@ -3334,10 +3356,13 @@
       }
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "tfunk": {
       "version": "3.1.0",
@@ -3347,6 +3372,33 @@
       "requires": {
         "chalk": "^1.1.1",
         "object-path": "^0.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "to-array": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "chalk": "^2.4.1",
     "lite-server": "^2.3.0",
     "sleep": "^5.2.3"
   }

--- a/test/helpers/wait.js
+++ b/test/helpers/wait.js
@@ -1,0 +1,13 @@
+const sleep = require('sleep')
+const chalk = require('chalk')
+
+function log(x) {
+  process.stdout.write(chalk.yellow(x))
+}
+
+module.exports = function (secs) {
+    secs = secs || 1
+  log(`Sleeping for ${secs} second${secs === 1 ? '' : 's'}...`)
+    sleep.sleep(secs || 1)
+  log(' Slept.\n')
+}

--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -1,4 +1,4 @@
-var sleep = require('sleep')
+var wait = require('./helpers/wait')
 var MetaCoin = artifacts.require("./MetaCoin.sol");
 
 // The following tests require TronBox >= 2.1.x
@@ -20,18 +20,18 @@ contract('MetaCoin', function (accounts) {
   it("should call a function that depends on a linked library", async function () {
     this.timeout(10000);
     const meta = await MetaCoin.deployed();
+    wait(1);
     const metaCoinBalance = (await meta.getBalance.call(accounts[0])).toNumber();
     const metaCoinEthBalance = (await meta.getBalanceInEth.call(accounts[0])).toNumber();
-    sleep.sleep(1);
     assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");
   });
 
   it("should send coins from account 0 to 1", async function () {
     this.timeout(10000)
     const meta = await MetaCoin.deployed();
+    wait(3);
     const account_one_starting_balance = (await meta.getBalance.call(accounts[0])).toNumber();
     const account_two_starting_balance = (await meta.getBalance.call(accounts[1])).toNumber();
-    sleep.sleep(1);
     await meta.sendCoin(accounts[1], 10, {
       from: accounts[0]
     });
@@ -42,6 +42,7 @@ contract('MetaCoin', function (accounts) {
   it("should send coins from account 1 to 2", async function () {
     this.timeout(20000)
     const meta = await MetaCoin.deployed();
+    wait(3);
     const account_two_starting_balance = (await meta.getBalance.call(accounts[1])).toNumber();
     const account_three_starting_balance = (await meta.getBalance.call(accounts[2])).toNumber();
     await meta.sendCoin(accounts[2], 5, {

--- a/tronbox.js
+++ b/tronbox.js
@@ -5,18 +5,30 @@ module.exports = {
       privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
       consume_user_resource_percent: 30,
       fee_limit: 100000000,
+
+      // Requires TronBox 2.1.9+ and Tron Quickstart 1.1.16+
+      fullHost: "http://127.0.0.1:9090",
+
+      // The three settings below for TronBox < 2.1.9.
       fullNode: "http://127.0.0.1:8090",
       solidityNode: "http://127.0.0.1:8091",
       eventServer: "http://127.0.0.1:8092",
+
       network_id: "*"
     },
     shasta: {
       privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
       consume_user_resource_percent: 30,
       fee_limit: 100000000,
+
+      // tronbox 2.1.9+
+      fullHost: "https://api.shasta.trongrid.io",
+
+      // tronbox < 2.1.9
       fullNode: "https://api.shasta.trongrid.io",
       solidityNode: "https://api.shasta.trongrid.io",
       eventServer: "https://api.shasta.trongrid.io",
+
       network_id: "*"
     },
     mainnet: {
@@ -25,9 +37,15 @@ module.exports = {
       privateKey: process.env.PK,
       consume_user_resource_percent: 30,
       fee_limit: 100000000,
+
+      // tronbox 2.1.9+
+      fullHost: "https://api.trongrid.io",
+
+      // tronbox < 2.1.9
       fullNode: "https://api.trongrid.io",
       solidityNode: "https://api.trongrid.io",
       eventServer: "https://api.trongrid.io",
+
       network_id: "*"
     }
   }


### PR DESCRIPTION
This version uses the new TronBox 2.1.9 `fullHost` parameter, remaining compatible with previous version.